### PR TITLE
如果程序存在子目录，且子目录不为空，则会报目录不为空的错误

### DIFF
--- a/MAutoUpdate/UpdateWork.cs
+++ b/MAutoUpdate/UpdateWork.cs
@@ -323,7 +323,7 @@ namespace MAutoUpdate
             {
                 if (item.Name != "bak" && item.Name != "temp")
                 {
-                    item.Delete();
+                    item.Delete(true);
                 }
             }
             return this;


### PR DESCRIPTION
如果程序存在子目录，且子目录不为空，则会报目录不为空的错误